### PR TITLE
Arregla error cuando se ejecuta el comando PARSE con --NoValidate

### DIFF
--- a/ede/ede/consoleMenu.py
+++ b/ede/ede/consoleMenu.py
@@ -80,7 +80,7 @@ class consoleMenu:
       args.path_to_DB_file = insertCSVtoSQLite.args.path_to_DB_file
       self.check(args)
     else:
-      logging.warning()("No se realiza validación de los datos, el parámetro '--NoValidate' se encuentra activado...")
+      logging.warning("No se realiza validación de los datos, el parámetro '--NoValidate' se encuentra activado...")
     
   def check(self, args):
     logger.info(f"Iniciando check: args")


### PR DESCRIPTION
* Arregla una llamada a `logging.warning` que tenía un par de paréntesis vacíos por error.