### PR TITLE
Agrega shell script parar correr parseCSVtoEDE.py en el ambiente del contenedor

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+# Run parseCSVtoEDE.py in the container environment with provided arguments.
+# For example,
+# ./run.sh parse --help
+# 
+# Works unix-like systems (linux, mac)
+# 
+# TODO: add support for Windows
+
+docker run -it --rm --name etl -v ${PWD}:/usr/src/ede -w /usr/src/ede edemineduc/etl python3 parseCSVtoEDE.py $@


### PR DESCRIPTION
Agrega un pequeño script que permite ejecutar `parseCSVtoEDE.py` en el ambiente del contenedor sin especificarlo en cada comando. Por ejemplo, 

````
./run.sh parse --help
````

es equivalente a 
````
docker run -it --rm --name etl -v ${directorio-de-trabajo}:/usr/src/ede -w /usr/src/ede edemineduc/etl python3 parseCSVtoEDE.py parse --help
````

Por ahora funciona solo en linux y mac.