### PR TITLE
Definicion de comprimible de salida

### DIFF
--- a/ede/ede/consoleMenu.py
+++ b/ede/ede/consoleMenu.py
@@ -18,6 +18,7 @@ class consoleMenu:
     parser_parseCSVtoSQL.add_argument('-nz','--nozip', help='Indica que el archivo no esta comprimido', action="store_true")
     parser_parseCSVtoSQL.add_argument('path_to_file', type=str, help="nombre del archivo a transformar")
     parser_parseCSVtoSQL.add_argument('-d','--debug', help='Aumenta el detalle de la salida', action="store_true")
+    parser_parseCSVtoSQL.add_argument('-o', '--output', type=str, help='Indica el nombre del archivo de salida')
     parser_parseCSVtoSQL.set_defaults(func=self.parse)
     
     # create the parser for the "insert" command
@@ -25,6 +26,7 @@ class consoleMenu:
     parser_insert.add_argument('--NoValidate', action='store_true', help="Desabilita la validación por defecto de los datos")
     parser_insert.add_argument('-d','--debug', help='Aumenta el detalle de la salida', action="store_true")
     parser_insert.add_argument('-e','--email', type=str, help='Indica el email del destinatario')    
+    parser_insert.add_argument('-o','--output', type=str, help='Indica el nombre del archivo de salida')
     parser_insert.set_defaults(func=self.insert)
     
     # create the parser for the "check" command

--- a/parseCSVtoEDE.py
+++ b/parseCSVtoEDE.py
@@ -8,6 +8,7 @@ import io, os, sys
 from datetime import datetime
 from pytz import timezone 
 from time import time #importamos la función time para capturar tiempos
+from pathlib import Path
 
 def module_from_file(module_name, file_path):
     spec = importlib.util.spec_from_file_location(module_name, file_path)
@@ -59,8 +60,26 @@ def main():
     args.func(args); #Ejecuta la función por defecto
   else:
     logger.info(parser.format_help())
-    
-  zipFile = ZipFile(f'./{t_stamp}_Data.zip','a')
+
+  try:
+    args.output
+  except AttributeError:
+    output = f'{t_stamp}_Data.zip'
+  else:
+    if (args.output is not None):
+      output = args.output
+    else:
+      output = f'{t_stamp}_Data.zip'
+  try:
+    destination = f'./{output}'
+    Path(os.path.dirname(destination)).mkdir(parents=True, exist_ok=True)
+    zipFile = ZipFile(destination, 'a')
+  except Exception as e:
+    logger.error(f"Error de comprimible: '{str(e)}'")
+    sys.exit(str(e))
+
+  logger.info(f"Comprimido en: '{destination}'")
+
   listFiles = [
     f'./{t_stamp}_key.txt',
     f'./{t_stamp}_key.encrypted',


### PR DESCRIPTION
Se agrego la posibilidad de definir la ruta y el nombre del archivo de salida tanto para el comando `insert` y el comando `parse` de manera opcional.

Ejemplos:

`docker run -it --rm --name etl -v "$(pwd)":/usr/src/ede -w /usr/src/ede edemineduc/etl python3 parseCSVtoEDE.py insert -e admin@ede.mineduc.cl -o output/nombre-personalizado.zip`

`docker run -it --rm --name etl -v "$(pwd)":/usr/src/ede -w /usr/src/ede edemineduc/etl python3 parseCSVtoEDE.py parse -nz json -o intermediate.zip 52364.json`