### PR TITLE
Cambio índice erróneo de array para descripción de incidencias

### DIFF
--- a/ede/ede/checkSQLiteEDE.py
+++ b/ede/ede/checkSQLiteEDE.py
@@ -6987,7 +6987,7 @@ GROUP BY Organizationid, date
           incidentDesc = incident[5]
           RefIncidentBehaviorId = incident[6]
           isJsonValidRegulationViolatedDesc = validateJSON(incident[16])
-          refIncidentBehaviorDesc = incident[66]
+          refIncidentBehaviorDesc = incident[67]
           PersonId = incident[72]
           refIncidentPersonId = incident[75]
           incidentPersonDate = incident[76]


### PR DESCRIPTION
La referencia del índice indicada en el array no se correspondía con la columna de descripción de incidencias provocando el fallo en la validación con esta función.